### PR TITLE
Added in ADroppedItemEgg functions

### DIFF
--- a/version/Core/Public/API/ARK/Actor.h
+++ b/version/Core/Public/API/ARK/Actor.h
@@ -7807,6 +7807,19 @@ struct ADroppedItemEgg : ADroppedItem
 
 	BitFieldValue<bool, unsigned __int32> bIsEggTooHot() { return { this, "ADroppedItemEgg.bIsEggTooHot" }; }
 	BitFieldValue<bool, unsigned __int32> bIsEggTooCold() { return { this, "ADroppedItemEgg.bIsEggTooCold" }; }
+
+	// Functions 
+
+	void UpdateEgg(float DeltaSeconds) { NativeCall<void, float>(this, "ADroppedItemEgg.UpdateEgg", DeltaSeconds); }
+	void Tick(float DeltaTime) { NativeCall<void, float>(this, "ADroppedItemEgg.Tick", DeltaTime); }
+	static UClass* StaticClass() { return NativeCall<UClass*>(nullptr, "ADroppedItemEgg.StaticClass"); }
+	void Stasis() { NativeCall<void>(this, "ADroppedItemEgg.Stasis"); }
+	void NetSpawnDinoEmitter() { NativeCall<void>(this, "ADroppedItemEgg.NetSpawnDinoEmitter"); }
+	void NetSpawnDinoEmitter_Implementation() { NativeCall<void>(this, "ADroppedItemEgg.NetSpawnDinoEmitter_Implementation"); }
+	static UClass* GetPrivateStaticClass(const wchar_t* Package) { return NativeCall<UClass*, const wchar_t*>(nullptr, "ADroppedItemEgg.GetPrivateStaticClass", Package); }
+	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>* OutLifetimeProps) { NativeCall<void, TArray<FLifetimeProperty>*>(this, "ADroppedItemEgg.GetLifetimeReplicatedProps", OutLifetimeProps); }
+	void CalcInsulation() { NativeCall<void>(this, "ADroppedItemEgg.CalcInsulation"); }
+	void BeginPlay() { NativeCall<void>(this, "ADroppedItemEgg.BeginPlay"); }
 };
 
 struct AMatineeActor : AActor


### PR DESCRIPTION
Left out:
// void execNetSpawnDinoEmitter(FFrame &,void * const)
Since FFrame Definition doesn't exist 
